### PR TITLE
Include LICENSE in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
Noticed it wasn't in there when putting together the package recipe for conda-forge.